### PR TITLE
Updated `bringToFront`

### DIFF
--- a/SKTUtils/SKNode+Extensions.swift
+++ b/SKTUtils/SKNode+Extensions.swift
@@ -47,9 +47,10 @@ public extension SKNode {
    * Makes this node the frontmost node in its parent.
    */
   public func bringToFront() {
-    let parent = self.parent
-    removeFromParent()
-    parent.addChild(self)
+    if let parent = self.parent{
+      removeFromParent()
+      parent.addChild(self)
+    }
   }
 
   /**


### PR DESCRIPTION
In beta 7, `self.parent` became a normal optional, not explicitly unwrapped. This causes the constant `parent` to be an optional. This new implementation handles the case where the node does not have a parent, and prevents having to explicitly unwrap later on.
