### PR TITLE
Updated to the latest Swift 3 standards.

### DIFF
--- a/SKTUtils/SKAction+SpecialEffects.swift
+++ b/SKTUtils/SKAction+SpecialEffects.swift
@@ -85,7 +85,7 @@ public extension SKAction {
   public class func colorGlitchWithScene(scene: SKScene, originalColor: SKColor, duration: NSTimeInterval) -> SKAction {
     return SKAction.customActionWithDuration(duration) {(node, elapsedTime) in
       if elapsedTime < CGFloat(duration) {
-        scene.backgroundColor = SKColorWithRGB(Int.random(0...255), g: Int.random(0...255), b: Int.random(0...255))
+        scene.backgroundColor = SKColorWithRGB(Int.random(0,255), g: Int.random(0,255), b: Int.random(0,255))
       } else {
         scene.backgroundColor = originalColor
       }


### PR DESCRIPTION
Edited the random() function call in colorGlitchWithScene() to work correctly with Swift 3. 

I was having an issue when I updated to Swift 3 using the XCode 8 beta, and changing the function as I am proposing fixed the problem.
