### PR TITLE
Changed function name to follow Swift 3 naming guidelines.

### DIFF
--- a/SKTUtils/CGVector+Extensions.swift
+++ b/SKTUtils/CGVector+Extensions.swift
@@ -82,7 +82,7 @@ public extension CGVector {
   /**
    * Calculates the distance between two CGVectors. Pythagoras!
    */
-  public func distanceTo(vector: CGVector) -> CGFloat {
+  public func distance(to vector: CGVector) -> CGFloat {
     return (self - vector).length()
   }
 


### PR DESCRIPTION
Please refer to the [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/#naming).

:)
